### PR TITLE
Add basic http authentication

### DIFF
--- a/app/controllers/inventories_controller.rb
+++ b/app/controllers/inventories_controller.rb
@@ -1,4 +1,6 @@
 class InventoriesController < ApplicationController
+  http_basic_authenticate_with name: ENV["USERNAME"], password: ENV["PASSWORD"]
+
   def index
     @inventories = Inventory.all_ordered
     @inventory = Inventory.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,4 +99,9 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # Test HTTP basic authentication details
+  # see `app/controllers/inventories_controller.rb`
+  ENV["USERNAME"] = 'test'
+  ENV["PASSWORD"] = 'test'
 end


### PR DESCRIPTION
To stop just anyone from destroying data, add basic http authentication.
- Environment variables are already configured on Heroku
- Rails version already bumped because of a recent vulnerability:
  https://groups.google.com/forum/#!msg/rubyonrails-security/ANv0HDHEC3k/mt7wNGxbFQAJ
