### PR TITLE
Remove `V1` fields

### DIFF
--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -4,12 +4,6 @@ class InventoryItem
 
   GOVUK_BASE_URL = 'https://www.gov.uk'
 
-  # maps incoming fields in the spreadsheet row to attributes on this model
-  V1_FIELD_POSITIONS = [ :url, :title, :last_updated,
-    :format, :display_type, :document_type, :topics, :mainstream_browse_pages,
-    :organisations, :policies, :document_collections, :is_withdrawn, :in_history_mode, 
-    :first_published_date, :matching_queries, :recommendation, :redirect_combine_url, :notes ]
-
   FIELD_POSITIONS = [ :title, :url, :description, :first_published_date, :last_updated, 
     :organisations, :format, :display_type, :policies, :topics, :mainstream_browse_pages, :document_collections,
     :is_withdrawn, :in_history_mode, :matching_queries, :relevance, :recommendation, :redirect_combine_url, :notes ]

--- a/db/migrate/20160125161626_drop_version_column.rb
+++ b/db/migrate/20160125161626_drop_version_column.rb
@@ -1,0 +1,5 @@
+class DropVersionColumn < ActiveRecord::Migration
+  def change
+    remove_column :inventories, :version
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160113141242) do
+ActiveRecord::Schema.define(version: 20160125161626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 20160113141242) do
     t.datetime "date_generated"
     t.boolean  "background_job_in_progress", default: false
     t.string   "flash_notes"
-    t.integer  "version"
   end
 
 end


### PR DESCRIPTION
`V1` field positions are no longer needed, or used.
- drop version column from Inventories table
- remove `V1_FIELD_POSITIONS`
