### PR TITLE
Mergeable fields should be cleared on regenerate

### DIFF
--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -92,6 +92,14 @@ class InventoryItem
     end
   end
 
+  def reset_mergeable_fields!
+    # We need to reset these fields when we regenerate the spreadsheet, so that
+    # we are only merging new query results
+    MERGEABLE_FIELDS.each do |fieldname|
+      send(putter_method(fieldname), [])
+    end
+  end
+
 private
   def remove_not_returned
     @notes.gsub!(/Not returned from search as of .*;\s/, '') if @notes
@@ -123,7 +131,9 @@ private
   end
 
   def merge_arrays(other_item, fieldname)
-    (send(fieldname) | other_item.send(fieldname)).sort
+    current_value = send(fieldname) || []
+    other_value = other_item.send(fieldname) || []
+    (current_value | other_value).sort
   end
 
   def extract_field(doc, fieldname, nil_value = 'Unknown')

--- a/app/models/inventory_item_collection.rb
+++ b/app/models/inventory_item_collection.rb
@@ -24,6 +24,7 @@ class InventoryItemCollection
 
   def self.new_from_search_queries(inventory, query_rows)
     inventory.log :info, "#{self} instantiating from queries"
+
     iic = new(:query)
     query_rows.each_with_index do |query_row, index|
       next if query_row.empty?
@@ -61,6 +62,11 @@ class InventoryItemCollection
     unless @source == :sheet && query_collection.source == :query
       raise "#merge_collections! must be called on an instance created from a spreadsheet and passed an instance created from a query"
     end
+
+    items.each do |spreadsheet_item|
+      spreadsheet_item.reset_mergeable_fields!
+    end
+
     query_collection.items.each do |query_collection_item|
       update_item(query_collection_item)
       (item_urls - query_collection.item_urls).each do |url|


### PR DESCRIPTION
Currently we merge fields like matching queries with whatever is there
at the moment. We want to ensure they are merged when combining successive query results,
but we need to clear it at the beginning or outdated values get preserved.

This is most visible when renaming a query and then regenerating.
