### PR TITLE
Fix number of attributes sent to Inventory#log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ capybara-*.html
 **.orig
 rerun.txt
 pickle-email-*.html
+redis.conf
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -55,7 +55,7 @@ class Inventory < ActiveRecord::Base
   end
 
   def start_background_job!(message)
-    log(message)
+    log(:info, message)
     update_attributes(background_job_in_progress: true, flash_notes: message)
   end
 


### PR DESCRIPTION
Inventory#log expects 2 attributes, but when `start_background_job!` is used in the InventoriesController it only sends the message attribute, without specifying the level, which I've assumed it's `:info`.

```
{"level":"error","message":"ArgumentError: wrong number of arguments (given 1, expected 2)
/var/govuk/inventory-tool/app/models/inventory.rb:28
...
```
