### PR TITLE
Replace homegrown error tracking with Appsignal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'factory_girl_rails', '~> 4.5'
 gem 'sidekiq', '~> 4.0'
 
 gem 'newrelic_rpm'
+gem 'appsignal'
 
 group :development do
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,9 @@ GEM
     annotate (2.7.0)
       activerecord (>= 3.2, < 6.0)
       rake (~> 10.4)
+    appsignal (1.0.4)
+      rack
+      thread_safe
     arel (5.0.1.20140414130214)
     ast (2.2.0)
     astrolabe (1.3.1)
@@ -275,6 +278,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  appsignal
   awesome_print
   better_errors
   binding_of_caller

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,13 +2,4 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-
-  rescue_from StandardError, with: :log_error
-
-  def log_error(exception)
-    message = "#{exception.class}: #{exception.message}\n#{exception.backtrace.join("\n")}"
-    ActivityLog.error(message)
-    flash[:danger] = "An excpetion has been trapped - view ActivityLogs for details"
-    redirect_to '/'
-  end
 end

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,7 @@
+development:
+  active: false
+
+production:
+  active: true
+  push_api_key: "<%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
+  name: "GOV.UK Content Inventory"

--- a/spec/controllers/inventories_controller_spec.rb
+++ b/spec/controllers/inventories_controller_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe InventoriesController, type: :controller do
       expect(response).to have_http_status(:success)
       expect(response).to render_template("index")
     end
-
-    it 'writes to the Activity log if there is an exception' do
-      expect(Inventory).to receive(:all_ordered).and_raise(RuntimeError, 'Dummy Exception')
-      expect(ActivityLog).to receive(:error).with(anything)
-
-      http_login
-      get :index
-    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
This app tracks exceptions by logging them to the Rails log, where nobody will notice them. This PR replaces this with sending the exceptions to Appsignal.

Once this PR has been merged I'll give the team access to Appsignal.
